### PR TITLE
Add ORG env variable

### DIFF
--- a/.aws/endyBot-task-definition.json
+++ b/.aws/endyBot-task-definition.json
@@ -18,6 +18,10 @@
               {
                   "name": "DEV",
                   "value": "0"
+              },
+              {
+                  "name": "ORG",
+                  "value": "https://liatrio.slack.com/archives/"
               }
           ],
           "environmentFiles": [],


### PR DESCRIPTION
This variable is used when generating the link to an EOD thread