### PR TITLE
Adding mocking for our modules

### DIFF
--- a/src/__mocks__/db.js
+++ b/src/__mocks__/db.js
@@ -1,0 +1,7 @@
+/* eslint-env jest */
+
+module.exports = {
+  addToDB: jest.fn(() => Promise.resolve()),
+  listGroups: jest.fn(() => Promise.resolve()),
+  getGroup: jest.fn(() => Promise.resolve())
+}

--- a/src/__mocks__/helpers.js
+++ b/src/__mocks__/helpers.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+
+module.exports = {
+  groupNameFromMessage: jest.fn()
+}

--- a/src/__mocks__/schedule.js
+++ b/src/__mocks__/schedule.js
@@ -1,0 +1,7 @@
+/* eslint-env jest */
+
+module.exports = {
+  startCronJobs: jest.fn(() => Promise.resolve()),
+  scheduleCronJob: jest.fn(() => Promise.resolve()),
+  convertPostTimeToCron: jest.fn()
+}

--- a/src/__mocks__/slack.js
+++ b/src/__mocks__/slack.js
@@ -1,0 +1,12 @@
+/* eslint-env jest */
+
+module.exports = {
+  createPost: jest.fn(() => Promise.resolve()),
+  dmUsers: jest.fn(() => Promise.resolve()),
+  validateInput: jest.fn(() => Promise.resolve()),
+  dmSubs: jest.fn(() => Promise.resolve()),
+  sendCreateModal: jest.fn(() => Promise.resolve()),
+  parseCreateModal: jest.fn(),
+  sendEODModal: jest.fn(() => Promise.resolve()),
+  updateEODModal: jest.fn()
+}


### PR DESCRIPTION
This mocks all of our functions we've written to empty functions for use when we're testing. 

If you're testing a function that calls some of our other functions from a different file, you'll just need to add 'jest.mock('../src/[file]')' right after the imports at the top of the test file, and it'll replace that function with an empty one by default. 