### PR TITLE
Added describeGroup function and testing for it

### DIFF
--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -296,7 +296,7 @@ describe('describeGroup testing suite', () => {
     }
     mockingoose(Group).toReturn(group, 'findOne')
     const result = await db.describeGroup('Group 1')
-    expect(result).toBe('Here\'s all the information for *Group 1*\n\n*Contributors*: <@UID123>  \n\n*Subscribers*: <@SID123>  \n\n*Channel*: <#test-channel>\n\n*EOD Time*: 14:00 PST\n')
+    expect(result).toBe('Here\'s all the information for *Group 1*\n\n*Contributors*: <@UID123>  \n\n*Subscribers*: <@SID123>  \n\n*Channel*: <#test-channel>\n\n*EOD Time*: 14:00 EST\n')
   })
 
   test('Describe nonexistent group', async () => {

--- a/src/app.js
+++ b/src/app.js
@@ -66,7 +66,7 @@ app.command(slashcommand, async ({ command, ack, respond }) => {
       break
     }
     case 'describe': {
-      const data = await database.describeGroup(group)
+      const data = await database.describeGroup(groupName)
       respond(data)
       break
     }

--- a/src/db.js
+++ b/src/db.js
@@ -160,7 +160,7 @@ async function describeGroup (groupname) {
     if (group === null) {
       return `No group exists with name *${groupname}*`
     }
-    
+
     // Examine group object and set up string to be returned
     // Set up string to be returned and printed from app.js
     let stringedResult = `Here's all the information for *${groupname}*\n\n`
@@ -201,6 +201,13 @@ async function describeGroup (groupname) {
 async function addSubscriber (groupname, userID) {
   try {
     // Obtain group object that points to the database
+    const group = await getGroup(groupname, undefined)
+
+    // In case the group doesn't exist, notify the user
+    if (group === null) {
+      return `No group exists with name *${groupname}*`
+    }
+
     // If the user is already subscribed to the group, notify them
     if (group.subscribers.includes(userID)) {
       return `You are already subscribed to *${groupname}*`


### PR DESCRIPTION
Closes #131 

- When a user calls '/endybot describe (group name)', this function returns a shiny looking print that displays the contributors, subscribers, post time and channel of the group.
- It returns this as a string that is concatenated together by following specific logic from within the function
- Added some tests to check the return value based on specific logic. More could be added for further reassurance.