### PR TITLE
Creating catalog-info.yaml for Backstage Auto Discovery

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,32 +2,24 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: endyBot
-  # description: Add a useful description before merging
+  description: A slackbot that organizes and tracks EOD threads
 
-  # Annotations Docs: https://backstage.io/docs/features/software-catalog/well-known-annotations
   annotations:
     github.com/project-slug: liatrio/endyBot
+    backstage.io/techdocs-ref: 'url:https://github.com/liatrio/endyBot'
 
-  # Tags Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#metadatatags-optional
-  # tags:
-  #   - example
-  #   - tag
+  tags:
+    - node
+    - javascript
+    - aws
+    - bolt
 
-  # Links Docs: https://backstage.io/docs/features/software-catalog/descriptor-format/#links-optional
-  # links:
-  #   - url: https://example.com/user
-  #     title: Examples Users
-  #     icon: user
-  #   - url: https://example.com/group
-  #     title: Example Group
-  #     icon: group
+  links:
+    - url: https://us-west-1.console.aws.amazon.com/ecs/v2/clusters/endyBot_cluster/services?region=us-west-1
+    - title: AWS Prod Cluster
+    - icon: dashboard
 
 spec:
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#spectype-required
   type: service
-  # Review lifecycle and pick one of the three that make the most sense.
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#speclifecycle-required
   lifecycle: production
-  # Please update to include the GitHub Team name tied to this project.
-  # https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
-  owner: liatrio-team-members
+  owner: immortal-hedgehogs


### PR DESCRIPTION
❗ This is not ready to merge. Please review the changeset and update based on your repository. ❗

Please give the catalog-info.yaml a review. It could use tags, links, a description and the correct owner. Each section has links to the related documentation.

Review the [catalog-info.yaml docs](https://backstage.io/docs/features/software-catalog/descriptor-format/)
Check out an example of our implementation in [gratibot](https://github.com/liatrio/gratibot/blob/main/catalog-info.yaml)

After you've finished and merged, this repository will auto discover in the Liatrio Backstage instance.

For any questions, please reach out on our Slack channel: #project-backstage-foundations