### PR TITLE
Add sub task

### DIFF
--- a/__tests__/app-helper.test.js
+++ b/__tests__/app-helper.test.js
@@ -93,3 +93,58 @@ describe('iterateEodSent() tests', () => {
     expect(res).toBe(null)
   })
 })
+
+describe('updateUser tests', () => {
+  test('Update user', () => {
+    const usrList = [
+      {
+        id: '12345',
+        name: 'Jesse'
+      },
+      {
+        id: '67891',
+        name: 'James'
+      }
+    ]
+
+    const event = {
+      user: {
+        id: '12345',
+        name: 'Ash'
+      }
+    }
+
+    appHelper.updateUser(usrList, event)
+
+    expect(usrList.length).toStrictEqual(2)
+    expect(usrList[0].name).toStrictEqual('Ash')
+    expect(usrList[0].id).toStrictEqual('12345')
+  })
+})
+
+describe('addUser tests', () => {
+  test('Add new user', () => {
+    const usrList = [
+      {
+        id: '12345',
+        name: 'Jesse'
+      },
+      {
+        id: '67891',
+        name: 'James'
+      }
+    ]
+
+    const event = {
+      user: {
+        id: '111213',
+        name: 'Ash'
+      }
+    }
+
+    appHelper.addUser(usrList, event)
+
+    expect(usrList.length).toStrictEqual(3)
+    expect(usrList[2]).toStrictEqual(event.user)
+  })
+})

--- a/__tests__/schedule.test.js
+++ b/__tests__/schedule.test.js
@@ -6,9 +6,6 @@ const Group = require('../db-schemas/group')
 const schedule = require('../src/schedule')
 const { App } = require('@slack/bolt')
 
-// including slack with a name so I can override default mocks
-const slack = require('../src/slack')
-
 // mocking out slack.js and db.js since they're used in schedule.js
 jest.mock('../src/slack')
 jest.mock('../src/db')
@@ -154,8 +151,8 @@ describe('schedule.js testing suite', () => {
         channel: 'CID123'
       }
 
-      // mock return values on all called functions
-      slack.getUserList.mockResolvedValue([
+      // mock usrList
+      const usrList = [
         {
           id: 'UID123',
           tz: 'Timezone'
@@ -168,12 +165,12 @@ describe('schedule.js testing suite', () => {
           id: 'UID789',
           tz: 'Timezone'
         }
-      ])
+      ]
 
       // mock allTasks
       const allTasks = []
 
-      await schedule.scheduleCronJob([], allTasks, group, app)
+      await schedule.scheduleCronJob([], allTasks, group, app, usrList)
 
       expect(allTasks.length).toEqual(1)
       expect(allTasks[0].contribTasks.length).toEqual(2)
@@ -190,13 +187,26 @@ describe('schedule.js testing suite', () => {
         channel: 'CID123'
       }
 
-      // mock return values on all called functions
-      slack.getUserList.mockResolvedValue(['usr1', 'usr2'])
+      // mock usrList
+      const usrList = [
+        {
+          id: 'UID123',
+          tz: 'Timezone'
+        },
+        {
+          id: 'UID456',
+          tz: 'Timezone'
+        },
+        {
+          id: 'UID789',
+          tz: 'Timezone'
+        }
+      ]
 
       // mock allTasks
       const allTasks = [{}, {}]
 
-      await schedule.scheduleCronJob([], allTasks, group, app)
+      await schedule.scheduleCronJob([], allTasks, group, app, usrList)
 
       expect(allTasks.length).toEqual(3)
     })
@@ -235,18 +245,18 @@ describe('schedule.js testing suite', () => {
         channel: 'CID123'
       }
 
-      // mock return values on all called functions
-      slack.getUserList.mockResolvedValue([
+      // mock usrList
+      const usrList = [
         {
           id: 'UID123',
           tz: 'Timezone'
         }
-      ])
+      ]
 
       // mock allTasks
       const allTasks = []
 
-      await schedule.scheduleCronJob([], allTasks, group, app)
+      await schedule.scheduleCronJob([], allTasks, group, app, usrList)
 
       expect(allTasks[0].contribTasks.length).toEqual(1)
     })
@@ -270,7 +280,7 @@ describe('schedule.js testing suite', () => {
   })
 
   describe('addSubscriberTask tests', () => {
-    const list = [
+    const allTasks = [
       {
         group: 'test_group1',
         threadTask: {
@@ -285,61 +295,7 @@ describe('schedule.js testing suite', () => {
         ],
         subTasks: [
           {
-            name: 'alice',
-            task: {
-              stop: jest.fn()
-            }
-          }
-        ]
-      },
-      {
-        group: 'test_group2',
-        threadTask: {
-          stop: jest.fn()
-        },
-        contribTasks: [
-          {
-            task: {
-              stop: jest.fn()
-            }
-          }
-        ],
-        subTasks: [
-          {
-            name: 'endy',
-            task: {
-              stop: jest.fn()
-            }
-          }
-        ]
-      },
-      {
-        group: 'test_group3',
-        threadTask: {
-          stop: jest.fn()
-        },
-        contribTasks: [
-          {
-            task: {
-              stop: jest.fn()
-            }
-          }
-        ],
-        subTasks: [
-          {
-            name: 'robert',
-            task: {
-              stop: jest.fn()
-            }
-          },
-          {
-            name: 'bobby',
-            task: {
-              stop: jest.fn()
-            }
-          },
-          {
-            name: 'bob',
+            name: 'UID123',
             task: {
               stop: jest.fn()
             }
@@ -347,10 +303,19 @@ describe('schedule.js testing suite', () => {
         ]
       }
     ]
-    test.only('addSubscriberTask', () => {
-      schedule.addSubscriberTask(app, list, 'test_group3', 'tommy')
-      console.log(list[2].group)
-      expect(list[2].subTasks.length).toEqual(4)
+
+    const usrList = [
+      {
+        id: 'UID123'
+      },
+      {
+        id: 'UID234'
+      }
+    ]
+
+    test('Add new subscriber', async () => {
+      await schedule.addSubscriberTask(app, allTasks, 'test_group1', 'UID234', usrList)
+      expect(allTasks[0].subTasks.length).toStrictEqual(2)
     })
   })
 

--- a/src/app-helper.js
+++ b/src/app-helper.js
@@ -71,4 +71,19 @@ async function iterateEodSent (app, eodSent, body) {
   return eodSent
 }
 
-module.exports = { commandParse, handleGroupDelete, iterateEodSent }
+function updateUser (usrList, event) {
+  // define test to filter list by
+  const changedUsr = (usr) => usr.id == event.user.id
+
+  // get index that matches test above
+  const ind = usrList.findIndex(changedUsr)
+
+  // update our user entry
+  usrList[ind] = event.user
+}
+
+function addUser (usrList, event) {
+  usrList.push(event.user)
+}
+
+module.exports = { commandParse, handleGroupDelete, iterateEodSent, updateUser, addUser }

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -36,13 +36,6 @@ async function scheduleCronJob (eodSent, allTasks, group, app, usrList) {
   }
 
   try {
-    // get user list so we can access contributor and subscriber timezones
-    usrList = await slack.getUserList(app)
-    if (typeof usrList != 'object') {
-      console.log('Unable to schedule cron job: Unable to get user list from Slack.')
-      return null
-    }
-
     // convert db postTime to cron time
     const cronTime = convertPostTimeToCron(group.postTime)
     if (cronTime == null) {
@@ -175,7 +168,6 @@ async function addSubscriberTask (app, allTasks, groupName, subscriber, usrList)
     }
 
     // look for users timezone
-
     const usrInfo = usrList.filter((usr) => usr.id == subscriber)
     if (usrInfo.length != 1) {
       // unable to locate user, try to add other group memebers
@@ -199,7 +191,6 @@ async function addSubscriberTask (app, allTasks, groupName, subscriber, usrList)
     }
 
     // now that we've scheduled the task and saved it in an obj
-
     for (const entry of allTasks) {
       if (entry.group === groupName) {
         entry.subTasks.push(subObj)


### PR DESCRIPTION
This PR corrects the bug where subscribers were not getting notified of EOD posts if they subscribed after group creation. This also reduces the number of API calls we make to slack by only grabbing the userList once on app startup, and updating that list whenever a user's profile is updated, or a new user joins the workspace.