### PR TITLE
Early post, closes #163

### DIFF
--- a/__mocks__/@slack/bolt.js
+++ b/__mocks__/@slack/bolt.js
@@ -10,7 +10,8 @@ module.exports = {
     client: {
       views: {
         open: jest.fn(() => Promise.resolve()),
-        update: jest.fn(() => Promise.resolve())
+        update: jest.fn(() => Promise.resolve()),
+        publish: jest.fn(() => Promise.resolve())
       },
       chat: {
         postMessage: jest.fn(() => Promise.resolve())

--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -16,7 +16,7 @@ describe('group.js testing suite', () => {
     const _group = {
       _id: '64dbee9baf23d8dc32bcbad3',
       name: 'Test Group',
-      contributors: ['UID12345'],
+      contributors: [{ name: 'UID12345' }],
       subscribers: ['UID56789'],
       postTime: 0,
       channel: '#test-channel',
@@ -35,7 +35,7 @@ describe('addToDB function', () => {
   test('should add a group to the database and return its ID', async () => {
     const fakeGroup = {
       name: 'test-group',
-      contributors: ['keoni', 'mikayla', 'carson'],
+      contributors: [{ name: 'keoni' }, { name: 'mikayla' }, { name: 'carson' }],
       subscribers: ['josh'],
       postTime: 5,
       channel: 'fake-channel',
@@ -84,7 +84,7 @@ describe('getGroup function', () => {
     const _group = {
       _id: '64e3e720f3e3e106543a0fbf',
       name: 'Test Group',
-      contributors: ['UID1234']
+      contributors: [{ name: 'UID1234' }]
     }
 
     mockingoose(Group).toReturn(_group, 'findOne')
@@ -102,17 +102,17 @@ describe('listGroups testing suite', () => {
     const groups = [
       {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['SID123']
       },
       {
         name: 'Group 2',
-        contributors: ['UID123'],
+        contributors: [{ name: 'UID123' }],
         subscribers: ['SID123']
       },
       {
         name: 'Group 3',
-        contributors: ['UID123', 'UID456', 'UID789'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }, { name: 'UID789' }],
         subscribers: ['SID789']
       }
     ]
@@ -128,7 +128,7 @@ describe('listGroups testing suite', () => {
     const groups = [
       {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['SID123']
       }
     ]
@@ -144,7 +144,7 @@ describe('listGroups testing suite', () => {
     const groups = [
       {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['SID123']
       }
     ]
@@ -268,7 +268,7 @@ describe('describeGroup testing suite', () => {
   test('Describe existing group', async () => {
     const group = {
       name: 'Group 1',
-      contributors: ['UID123'],
+      contributors: [{ name: 'UID123' }],
       subscribers: ['SID123'],
       postTime: 14,
       channel: 'test-channel'

--- a/__tests__/schedule.test.js
+++ b/__tests__/schedule.test.js
@@ -93,7 +93,7 @@ describe('schedule.js testing suite', () => {
     test('Handle cron job setup from single group in DB', async () => {
       const groups = [{
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UIS789'],
         postTime: 16,
         channel: 'CID123'
@@ -109,14 +109,14 @@ describe('schedule.js testing suite', () => {
     test('Handle cron job setup from multiple groups in DB', async () => {
       const groups = [{
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UIS789'],
         postTime: 16,
         channel: 'CID123'
       },
       {
         name: 'Group 2',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UIS789'],
         postTime: 16,
         channel: 'CID123'
@@ -145,7 +145,7 @@ describe('schedule.js testing suite', () => {
       // mock group
       const group = {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UID789'],
         postTime: 16,
         channel: 'CID123'
@@ -181,7 +181,7 @@ describe('schedule.js testing suite', () => {
       // mock group
       const group = {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UIS789'],
         postTime: 16,
         channel: 'CID123'
@@ -214,7 +214,7 @@ describe('schedule.js testing suite', () => {
     test('Skip adding a group with invalid time to schedule', async () => {
       const group = {
         name: 'Group 2',
-        contributors: ['UID123'],
+        contributors: [{ name: 'UID123' }],
         subscribers: ['UIS789'],
         postTime: 25,
         channel: 'CID123'
@@ -239,7 +239,7 @@ describe('schedule.js testing suite', () => {
       // mock group
       const group = {
         name: 'Group 1',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123' }, { name: 'UID456' }],
         subscribers: ['UIS789'],
         postTime: 16,
         channel: 'CID123'

--- a/__tests__/slack.test.js
+++ b/__tests__/slack.test.js
@@ -84,7 +84,7 @@ describe('slack.js testing suite', () => {
 
       const expected = {
         name: 'Test Group',
-        contributors: ['UID123', 'UID456'],
+        contributors: [{ name: 'UID123', posted: false }, { name: 'UID456', posted: false }],
         subscribers: ['UID789', 'UID1110'],
         postTime: 1,
         channel: 'CHID123',

--- a/db-schemas/group.js
+++ b/db-schemas/group.js
@@ -13,7 +13,7 @@ const Schema = mongoose.Schema
  */
 const groupSchema = Schema({
   name: String,
-  contributors: [String],
+  contributors: [JSON],
   subscribers: [String],
   postTime: Number,
   channel: String,

--- a/src/__mocks__/db.js
+++ b/src/__mocks__/db.js
@@ -5,5 +5,11 @@ module.exports = {
   listGroups: jest.fn(() => Promise.resolve()),
   getGroup: jest.fn(() => Promise.resolve()),
   deleteGroup: jest.fn(() => Promise.resolve()),
-  updatePosted: jest.fn(() => Promise.resolve())
+  describeGroup: jest.fn(() => Promise.resolve()),
+  addSubscriber: jest.fn(() => Promise.resolve()),
+  removeSubscriber: jest.fn(() => Promise.resolve()),
+  getUserGroups: jest.fn(() => Promise.resolve()),
+  checkUserPosted: jest.fn(() => Promise.resolve()),
+  updateUserPosted: jest.fn(() => Promise.resolve()),
+  updateGroupPosted: jest.fn(() => Promise.resolve())
 }

--- a/src/__mocks__/helpers.js
+++ b/src/__mocks__/helpers.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   groupNameFromMessage: jest.fn(),
-  formatEODResponse: jest.fn()
+  formatEODResponse: jest.fn(),
+  constructHomeView: jest.fn(() => Promise.resolve())
 }

--- a/src/__mocks__/slack.js
+++ b/src/__mocks__/slack.js
@@ -1,17 +1,18 @@
 /* eslint-env jest */
 
 module.exports = {
-  createPost: jest.fn(() => Promise.resolve()),
-  dmUsers: jest.fn(() => Promise.resolve()),
-  validateInput: jest.fn(() => Promise.resolve()),
-  dmSubs: jest.fn(() => Promise.resolve()),
   sendCreateModal: jest.fn(() => Promise.resolve()),
   parseCreateModal: jest.fn(),
   sendEODModal: jest.fn(() => Promise.resolve()),
   updateEODModal: jest.fn(),
+  dmUsers: jest.fn(() => Promise.resolve()),
+  createPost: jest.fn(() => Promise.resolve()),
+  postEODResponse: jest.fn(() => Promise.resolve()),
+  dmSubs: jest.fn(() => Promise.resolve()),
   notifySubsAboutGroupDeletion: jest.fn(() => Promise.resolve()),
-  getUserList: jest.fn(() => Promise.resolve()),
   eodDmUpdateDelete: jest.fn(() => Promise.resolve()),
   eodDmUpdatePost: jest.fn(() => Promise.resolve()),
-  sendMessage: jest.fn(() => Promise.resolve())
+  getUserList: jest.fn(() => Promise.resolve()),
+  sendMessage: jest.fn(() => Promise.resolve()),
+  sendHomeView: jest.fn(() => Promise.resolve())
 }

--- a/src/db.js
+++ b/src/db.js
@@ -265,12 +265,93 @@ async function removeSubscriber (groupname, userID) {
 }
 
 /**
+ * @param {String} userID - Slack ID of the user to find all groups for
+ * @returns a list of the groups a user is in
+ */
+async function getUserGroups (userID) {
+  // declare here so it's recognized in every try block
+  let groups
+  try {
+    // Gather all groups from the database
+    groups = await Group.find({})
+    if (groups.length == 0) {
+      return []
+    }
+  } catch (error) {
+    return `Error while gathering groups from database: ${error.message}`
+  }
+
+  const userGroups = []
+
+  try {
+    // Check all contributor lists to populate arrays
+    for (const group of groups) {
+      for (const contrib of group.contributors) {
+        if (contrib.name == userID) {
+          userGroups.push(group)
+        }
+      }
+    }
+  } catch (error) {
+    return `Error while parsing through subscriber lists in listGroups: ${error.message}`
+  }
+
+  return userGroups
+}
+
+/**
+ * Checks if the given user has posted for this group today or not
+ * @param {String} UID - Slack User ID
+ * @returns bool
+ */
+async function checkUserPosted (UID, groupName) {
+  try {
+    const group = await Group.find({ name: groupName })
+
+    for (const i in group[0].contributors) {
+      if (group[0].contributors[i].name == UID) {
+        return group[0].contributors[i].posted
+      }
+    }
+
+    return -1
+  } catch (error) {
+    console.log(`Error checking if user posted: ${error}`)
+    return -1
+  }
+}
+
+/**
+ * Finds the user in the contributors list of the given group and updates their posted bool to the given one here
+ * @param {String} user
+ * @param {JSON} groupName
+ * @param {bool} posted
+ */
+async function updateUserPosted (user, groupName, posted) {
+  try {
+    const group = await Group.find({ name: groupName })
+
+    for (const i in group[0].contributors) {
+      if (group[0].contributors[i].name == user) {
+        group[0].contributors[i].posted = posted
+        group[0].markModified('contributors')
+        await group[0].save()
+      }
+    }
+  } catch (error) {
+    console.log(`Unable to update posted status for user ${user} in group ${groupName}: ${error}`)
+    return -1
+  }
+  return 0
+}
+
+/**
  * Updates the posted varaible in a group. If ts is provided, posted is set to true. If no ts is provided, posted is set to false.
  * @param {JSON} group
  * @param {String} ts
  * @returns The updated group object on success, and null on failure
  */
-async function updatePosted (group, ts) {
+async function updateGroupPosted (group, ts) {
   try {
     if (!ts) {
       group.posted = false
@@ -288,4 +369,4 @@ async function updatePosted (group, ts) {
   }
 }
 
-module.exports = { addToDB, listGroups, getGroup, deleteGroup, describeGroup, addSubscriber, removeSubscriber, updatePosted }
+module.exports = { addToDB, listGroups, getGroup, deleteGroup, describeGroup, addSubscriber, removeSubscriber, getUserGroups, checkUserPosted, updateUserPosted, updateGroupPosted }

--- a/src/db.js
+++ b/src/db.js
@@ -173,7 +173,7 @@ async function describeGroup (groupname) {
     // Display all contributors of the group
     stringedResult += '*Contributors*: '
     for (const user of group.contributors) {
-      stringedResult += `<@${user}>  `
+      stringedResult += `<@${user.name}>  `
     }
 
     // Display all subscribers of the group

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,21 +1,34 @@
+const db = require('./db')
 // put any helpers here that don't have any other good spot to go
 /**
  *
  * @param {String} message - Should be in the form 'It's time to write your EOD post for \*[GROUP NAME]!\*"
  * @returns The group name from the message above. Will return -1 on error.
  */
-function groupNameFromMessage (message) {
-  const splitMessage = message.split('*')
-  if (splitMessage.length != 3) {
-    // message was not 'It's time to write your EOD post for *[GROUPNAME]!*
-    return -1
+function groupNameFromMessage (body) {
+  // getting group name from different places depending on button source
+  if (body.container.type == 'message') {
+    // parsing group name
+    const splitMessage = body.message.text.split('*')
+    if (splitMessage.length != 3) {
+      // Group name was not surrounded by *
+      return -1
+    }
+    const groupName = splitMessage[1]
+    if (groupName.length < 2) {
+      // group name was empty
+      return -1
+    }
+    return groupName.substring(0, groupName.length - 1)
+  } else if (body.container.type == 'view') {
+    const splitMessage = body.actions[0].text.text.split(' ')
+    if (splitMessage.length != 4) {
+      // Message was not in form "write groupname eod post"
+      return -1
+    }
+
+    return splitMessage[1]
   }
-  const groupName = splitMessage[1]
-  if (groupName.length < 2) {
-    // group name was empty
-    return -1
-  }
-  return groupName.substring(0, groupName.length - 1)
 }
 
 /**
@@ -132,4 +145,65 @@ function formatEODResponse (responseObj, uid) {
   return block
 }
 
-module.exports = { groupNameFromMessage, formatEODResponse }
+/**
+ * Creates the home view for a user when they open the home page
+ * @param {String} user - The Slack UID of target user
+ * @returns The view to send to the app homepage for that user
+ */
+async function constructHomeView (user) {
+  const userGroups = await db.getUserGroups(user)
+
+  const view = {
+    type: 'home',
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: 'Your EOD Groups',
+          emoji: true
+        }
+      },
+      {
+        type: 'divider'
+      }
+    ]
+  }
+
+  if (userGroups.length == 0) {
+    view.blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: 'Looks like you\'re not a contributor in any groups!'
+        }
+      }
+    )
+  }
+
+  for (const group in userGroups) {
+    view.blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `${userGroups[group].name}`
+        },
+        accessory: {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: `Write ${userGroups[group].name} EOD Post`,
+            emoji: true
+          },
+          action_id: 'write_eod'
+        }
+      }
+    )
+  }
+
+  return view
+}
+
+module.exports = { groupNameFromMessage, formatEODResponse, constructHomeView }

--- a/src/modal-views.js
+++ b/src/modal-views.js
@@ -391,4 +391,27 @@ const eodBoth = {
   ]
 }
 
-module.exports = { groupCreate, eodDefault, eodBlockers, eodNotes, eodBoth }
+const alreadyPosted = {
+  type: 'modal',
+  title: {
+    type: 'plain_text',
+    text: 'Cannot Make EOD Post',
+    emoji: true
+  },
+  close: {
+    type: 'plain_text',
+    text: 'Ok',
+    emoji: true
+  },
+  blocks: [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'You have already made your EOD post for this group today!'
+      }
+    }
+  ]
+}
+
+module.exports = { groupCreate, eodDefault, eodBlockers, eodNotes, eodBoth, alreadyPosted }

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -60,7 +60,7 @@ async function scheduleCronJob (eodSent, allTasks, group, app, usrList) {
 
     for (let i = 0; i < group.contributors.length; i++) {
       // get timezone
-      const usrInfo = usrList.filter((usr) => usr.id == group.contributors[i])
+      const usrInfo = usrList.filter((usr) => usr.id == group.contributors[i].name)
       if (usrInfo.length != 1) {
         // unable to locate user, try to add other group memebers
         console.log('Error: Unable to schedule task; could not find contributor')

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -43,9 +43,12 @@ async function scheduleCronJob (eodSent, allTasks, group, app, usrList) {
       return null
     }
 
-    // Scheduling task to reset the "posted" variable
-    const resetTask = cron.schedule('0 23 * * 1-5', async () => {
-      db.updatePosted(group)
+    // Scheduling task to reset the "posted" variable for the group and each contributor
+    const resetTask = cron.schedule('59 23 * * 1-5', async () => {
+      db.updateGroupPosted(group)
+      for (let i = 0; i < group.contributors.length; i++) {
+        db.updateUserPosted(group.contributors[i].name, group.name, false)
+      }
     }, {
       timezone: 'America/Los_Angeles' // PST-- Setting it to this to try to limitt cases of late-night EOD posts going to the wrong thread
     })

--- a/src/slack.js
+++ b/src/slack.js
@@ -181,9 +181,23 @@ function parseCreateModal (view) {
   try {
     const rawTime = view.state.values.create_time.group_create_time.selected_time
     const time = Number(rawTime.substring(0, 2))
+
+    // creating contributor objects
+    const contribs = []
+
+    for (let i = 0; i < view.state.values.contributors.group_create_contributors.selected_users.length; i++) {
+      const thisObj = {
+        name: '',
+        posted: false
+      }
+
+      thisObj.name = view.state.values.contributors.group_create_contributors.selected_users[i]
+      contribs.push(thisObj)
+    }
+
     const newGroup = {
       name: view.state.values.group_name.group_create_name.value,
-      contributors: view.state.values.contributors.group_create_contributors.selected_users,
+      contributors: contribs,
       subscribers: view.state.values.subscribers.group_create_subscribers.selected_users,
       postTime: time,
       channel: view.state.values.channel.group_create_channel.selected_channel,


### PR DESCRIPTION
This PR makes a lot of changes and required a bit of refactoring. 

The overall goal was to enable users to make their EOD posts before they get a reminder from endyBot.

In order to accomplish this, the group schema was updated to no longer be a list of strings, but rather a list of objects where each entry has a 'name' field (the slack uid) and a 'posted' field (bool indicating if the user has made their post for that group that day). Since that was changed, every spot contributors were referenced needed to be updated to reference the name attribute of each contributor object. 

That took care of tracking who's posted for which group, so next up was implementing a mechanism for users to initiate an EOD post without the endyBot notification. For this, I enabled a home screen for the endyBot app, where users are presented with a list of all groups they're contributors in, along with a button to write their EOD post. This button triggers the same modal as the one users are sent at their notification time. 

With these additions, I've also implemented some checks so that users don't get reminded to make their EOD posts if they've already made them today. 

The task that resets the 'posted' variable for the whole group now also resets that variable for each contributor of the group at the same time. 